### PR TITLE
fix: added  `pd` as a padding utility(#58)

### DIFF
--- a/packages/react/src/theme/stitches.config.ts
+++ b/packages/react/src/theme/stitches.config.ts
@@ -312,11 +312,8 @@ export const { styled, css, config, theme, createTheme, reset, getCssText, globa
       light: '(prefers-color-scheme: light)',
     },
     utils: {
-      p: (value: PropertyValue<'padding'>) => ({
-        padding:value,
-      }),
       pd: (value: PropertyValue<'padding'>) => ({
-        padding:value,
+        padding: value,
       }),
       pt: (value: PropertyValue<'paddingTop'>) => ({
         paddingTop: value,

--- a/packages/react/src/theme/stitches.config.ts
+++ b/packages/react/src/theme/stitches.config.ts
@@ -313,16 +313,10 @@ export const { styled, css, config, theme, createTheme, reset, getCssText, globa
     },
     utils: {
       p: (value: PropertyValue<'padding'>) => ({
-        paddingTop: value,
-        paddingBottom: value,
-        paddingLeft: value,
-        paddingRight: value,
+        padding:value,
       }),
       pd: (value: PropertyValue<'padding'>) => ({
-        paddingTop: value,
-        paddingBottom: value,
-        paddingLeft: value,
-        paddingRight: value,
+        padding:value,
       }),
       pt: (value: PropertyValue<'paddingTop'>) => ({
         paddingTop: value,

--- a/packages/react/src/theme/stitches.config.ts
+++ b/packages/react/src/theme/stitches.config.ts
@@ -315,6 +315,9 @@ export const { styled, css, config, theme, createTheme, reset, getCssText, globa
       p: (value: PropertyValue<'padding'>) => ({
         padding: value,
       }),
+      pd: (value: PropertyValue<'padding'>) => ({
+        padding: value,
+      }),
       pt: (value: PropertyValue<'paddingTop'>) => ({
         paddingTop: value,
       }),

--- a/packages/react/src/theme/stitches.config.ts
+++ b/packages/react/src/theme/stitches.config.ts
@@ -312,7 +312,7 @@ export const { styled, css, config, theme, createTheme, reset, getCssText, globa
       light: '(prefers-color-scheme: light)',
     },
     utils: {
-      pd: (value: PropertyValue<'padding'>) => ({
+      p: (value: PropertyValue<'padding'>) => ({
         padding: value,
       }),
       pt: (value: PropertyValue<'paddingTop'>) => ({

--- a/packages/react/src/theme/stitches.config.ts
+++ b/packages/react/src/theme/stitches.config.ts
@@ -318,6 +318,12 @@ export const { styled, css, config, theme, createTheme, reset, getCssText, globa
         paddingLeft: value,
         paddingRight: value,
       }),
+      pd: (value: PropertyValue<'padding'>) => ({
+        paddingTop: value,
+        paddingBottom: value,
+        paddingLeft: value,
+        paddingRight: value,
+      }),
       pt: (value: PropertyValue<'paddingTop'>) => ({
         paddingTop: value,
       }),


### PR DESCRIPTION
I added the `pd` padding utility to help prevent name clashing of the `p` padding utility with `<p>` element.


PS: I noticed the padding was spread out and I'm not sure if it's intentional.
![image](https://user-images.githubusercontent.com/63613078/213815483-f83e3ee2-8513-43c9-b282-811cfc8b74e6.png)
With the padding set like this, shorthand wouldn't be possible(i.e "10px 20px").
```css
p: "10px 20px"
```
 What do you think?