### PR TITLE
feat(wip): add avatar and group component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@radix-ui/colors": "0.1.8",
     "@radix-ui/react-aspect-ratio": "1.0.1",
+    "@radix-ui/react-avatar": "1.0.1",
     "@radix-ui/react-checkbox": "1.0.1",
     "@radix-ui/react-dialog": "1.0.2",
     "@radix-ui/react-dropdown-menu": "2.0.1",

--- a/packages/react/src/avatar/Avatar.stories.tsx
+++ b/packages/react/src/avatar/Avatar.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Flex } from '../layout';
-import { Avatar, AvatarFallback, AvatarImage, AvatarGroup } from './Avatar';
+import { Typography } from '../typography';
+import { Avatar, AvatarFallback, AvatarImage, AvatarGroup, AvatarGroupProps } from './Avatar';
 
 export default {
   title: 'Components/Media/Avatar',
@@ -71,8 +72,44 @@ export const FallbackSizes = () => (
   </Flex>
 );
 
-export const AvatarGroupDefault = () => (
-  <AvatarGroup limit={4}>
+export const AvatarGroupDefault = ({ stacking }: Pick<AvatarGroupProps, 'stacking'>) => (
+  <AvatarGroup stacking={stacking} limit={4}>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage
+        src={'https://images.unsplash.com/photo-1622737133809-d95047b9e673?w=300&dpr=2&q=80'}
+        alt=""
+      />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+  </AvatarGroup>
+);
+
+export const Stacking = () => (
+  <Flex direction="column" gap="10">
+    <Flex direction="column" gap="1">
+      <Typography>First on top</Typography>
+      <AvatarGroupDefault />
+    </Flex>
+    <Flex direction="column" gap="1">
+      <Typography>Last on top</Typography>
+      <AvatarGroupDefault stacking="lastOnTop" />
+    </Flex>
+  </Flex>
+);
+
+export const InteractiveIndicator = () => (
+  <AvatarGroup indicatorOnClick={() => alert('Hello, world!')} indicatorInteractive limit={4}>
     <Avatar>
       <AvatarImage src={AVATAR_URL} alt="" />
     </Avatar>

--- a/packages/react/src/avatar/Avatar.stories.tsx
+++ b/packages/react/src/avatar/Avatar.stories.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { Flex } from '../layout';
+import { Avatar, AvatarFallback, AvatarImage, AvatarGroup } from './Avatar';
+
+export default {
+  title: 'Components/Media/Avatar',
+  component: Avatar,
+};
+
+const AVATAR_URL =
+  'https://images.unsplash.com/photo-1506863530036-1efeddceb993?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1344&q=80';
+
+export const Default = () => (
+  <Avatar>
+    <AvatarImage
+      src="https://images.unsplash.com/photo-1622737133809-d95047b9e673?w=300&dpr=2&q=80"
+      alt="3D Render by Sebastian Svenson"
+    />
+  </Avatar>
+);
+
+export const Fallback = () => (
+  <Avatar>
+    <AvatarImage src="" alt="3D Render by Sebastian Svenson" />
+    <AvatarFallback>AU</AvatarFallback>
+  </Avatar>
+);
+
+export const FallbackColorScheme = () => (
+  <Avatar>
+    <AvatarImage src="" alt="3D Render by Sebastian Svenson" />
+    <AvatarFallback colorScheme="violet">AU</AvatarFallback>
+  </Avatar>
+);
+
+export const FallbackVariants = () => (
+  <Flex gap="3">
+    <Avatar>
+      <AvatarImage src="" alt="3D Render by Sebastian Svenson" />
+      <AvatarFallback colorScheme="violet">AU</AvatarFallback>
+    </Avatar>
+    <Avatar>
+      <AvatarImage src="" alt="3D Render by Sebastian Svenson" />
+      <AvatarFallback colorScheme="violet" variant="solid">
+        AU
+      </AvatarFallback>
+    </Avatar>
+  </Flex>
+);
+
+const sizes = ['1', '2', '3', '4', '5', '6', '7'];
+
+export const Sizes = () => (
+  <Flex gap="3">
+    {sizes.map((size) => (
+      <Avatar key={size} size={size as any}>
+        <AvatarImage src={AVATAR_URL} alt="3D Render by Sebastian Svenson" />
+      </Avatar>
+    ))}
+  </Flex>
+);
+
+export const FallbackSizes = () => (
+  <Flex gap="3">
+    {sizes.map((size) => (
+      <Avatar key={size} size={size as any}>
+        <AvatarImage src={''} alt="3D Render by Sebastian Svenson" />
+        <AvatarFallback colorScheme="violet">AU</AvatarFallback>
+      </Avatar>
+    ))}
+  </Flex>
+);
+
+export const AvatarGroupDefault = () => (
+  <AvatarGroup limit={4}>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="" />
+    </Avatar>
+  </AvatarGroup>
+);

--- a/packages/react/src/avatar/Avatar.stories.tsx
+++ b/packages/react/src/avatar/Avatar.stories.tsx
@@ -83,7 +83,10 @@ export const AvatarGroupDefault = () => (
       <AvatarImage src={AVATAR_URL} alt="" />
     </Avatar>
     <Avatar>
-      <AvatarImage src={AVATAR_URL} alt="" />
+      <AvatarImage
+        src={'https://images.unsplash.com/photo-1622737133809-d95047b9e673?w=300&dpr=2&q=80'}
+        alt=""
+      />
     </Avatar>
     <Avatar>
       <AvatarImage src={AVATAR_URL} alt="" />

--- a/packages/react/src/avatar/Avatar.tsx
+++ b/packages/react/src/avatar/Avatar.tsx
@@ -5,10 +5,12 @@ import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import { ColorScheme, getContrastingColor } from '../utils';
 import { Center, Flex } from '../layout';
 import { getValidChildren } from '../utils/react-children';
+import { compact } from '../utils/object-utils';
 
 export type AvatarProps = ComponentProps<typeof Avatar>;
 
 export const Avatar = styled(AvatarPrimitive.Root, {
+  position: 'relative',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -151,8 +153,8 @@ export const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallbackPr
 type AvatarGroupProps = ComponentProps<typeof StyledAvatarGroup> &
   AvatarProps & {
     limit?: number;
-    avatarBorderWidth?: number | string;
-    avatarBorderColor?: string;
+    border?: boolean;
+    borderColor?: string;
   };
 
 const StyledAvatarGroup = styled('div', Flex, {
@@ -165,9 +167,11 @@ const StyledAvatarGroup = styled('div', Flex, {
       firstOnTop: {
         '& span': {
           '&:not(:first-of-type)': {
-            ml: '-$3',
+            mr: '-$3',
           },
         },
+        justifyContent: 'flex-end',
+        flexDirection: 'row-reverse',
       },
       lastOnTop: {
         '& span': {
@@ -175,9 +179,6 @@ const StyledAvatarGroup = styled('div', Flex, {
             mr: '-$3',
           },
         },
-
-        // justifyContent: 'flex-end',
-        flexDirection: 'row-reverse',
       },
     },
   },
@@ -189,7 +190,7 @@ const StyledAvatarGroup = styled('div', Flex, {
 
 export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
   (
-    { children, avatarBorderWidth = '3px', avatarBorderColor = 'inherit', limit, size, ...rest },
+    { children, border, borderColor = 'inherit', limit, size, stacking = 'firstOnTop', ...rest },
     ref
   ) => {
     const validChildren = getValidChildren(children);
@@ -198,16 +199,35 @@ export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
 
     const reversedChildren = childrenWithinLimit.reverse();
 
-    const _children = React.Children.map(reversedChildren, (child) => {
-      return React.cloneElement(child as React.ReactElement<AvatarProps>, {
-        css: { boxShadow: `0 0 0 ${avatarBorderWidth} $colors$slate1` },
+    const _children = reversedChildren.map((child, index) => {
+      const firstAvatar = index === 0;
+
+      const childProps = {
         size: size,
-      });
+        css: {
+          mr: firstAvatar ? 0 : '$3',
+          boxShadow: `0 0 0 3px $colors$slate1`,
+        },
+      };
+
+      return React.cloneElement(child, compact(childProps));
     });
+
+    // const _children = React.Children.map(reversedChildren, (child) => {
+    //   return React.cloneElement(child as React.ReactElement<AvatarProps>, {
+    //     css: { boxShadow: `0 0 0 3px $colors$slate1` },
+    //     size: size,
+    //   });
+    // });
     return (
       <StyledAvatarGroup role="group" ref={ref} {...rest}>
+        {stacking === 'firstOnTop' && limit && limit < validChildren.length && (
+          <Avatar size={size} data-avatar="fallback">
+            <AvatarFallback>+{validChildren.length - limit}</AvatarFallback>
+          </Avatar>
+        )}
         {_children}
-        {limit && limit < validChildren.length && (
+        {stacking === 'lastOnTop' && limit && limit < validChildren.length && (
           <Avatar size={size} data-avatar="fallback">
             <AvatarFallback>+{validChildren.length - limit}</AvatarFallback>
           </Avatar>

--- a/packages/react/src/avatar/Avatar.tsx
+++ b/packages/react/src/avatar/Avatar.tsx
@@ -1,0 +1,218 @@
+import * as React from 'react';
+import { styled, ComponentProps } from '../theme';
+
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import { ColorScheme, getContrastingColor } from '../utils';
+import { Center, Flex } from '../layout';
+import { getValidChildren } from '../utils/react-children';
+
+export type AvatarProps = ComponentProps<typeof Avatar>;
+
+export const Avatar = styled(AvatarPrimitive.Root, {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  verticalAlign: 'middle',
+  overflow: 'hidden',
+  userSelect: 'none',
+
+  variants: {
+    size: {
+      1: {
+        size: '$5',
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$1',
+          lineHeight: '$1',
+        },
+      },
+      2: {
+        size: '$6',
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$1',
+          lineHeight: '$1',
+        },
+      },
+      3: {
+        size: '$7',
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$2',
+          lineHeight: '$2',
+        },
+      },
+      4: {
+        size: '$10',
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$2',
+          lineHeight: '$2',
+        },
+      },
+      5: {
+        size: '$16',
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$5',
+          lineHeight: '$5',
+        },
+      },
+      6: {
+        size: '$20',
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$6',
+          lineHeight: '$6',
+        },
+      },
+      7: {
+        size: 96,
+        '& span[data-avatar="fallback"]': {
+          fontSize: '$7',
+          lineHeight: '$7',
+        },
+      },
+    },
+    shape: {
+      round: {
+        br: '$round',
+      },
+      square: {
+        br: 0,
+      },
+    },
+  },
+
+  defaultVariants: {
+    size: '4',
+    shape: 'round',
+  },
+});
+
+export const AvatarImage = styled(AvatarPrimitive.Image, {
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  borderRadius: 'inherit',
+});
+
+type AvatarFallbackProps = ComponentProps<typeof StyledFallback> & {
+  colorScheme?: ColorScheme;
+};
+
+const StyledFallback = styled(AvatarPrimitive.Fallback, {
+  width: '100%',
+  height: '100%',
+
+  $$subtleBg: '$colors$slate3',
+  $$subtleColor: '$colors$slate11',
+
+  $$solidBg: '$colors$slate9',
+  $$solidColor: 'white',
+
+  variants: {
+    variant: {
+      subtle: {
+        backgroundColor: '$$subtleBg',
+        color: '$$subtleColor',
+        display: 'grid',
+        placeItems: 'center',
+      },
+      solid: {
+        backgroundColor: '$$solidBg',
+        color: '$$solidColor',
+        display: 'grid',
+        placeItems: 'center',
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'subtle',
+  },
+});
+
+export const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallbackProps>(
+  ({ colorScheme = 'slate', css, children, ...rest }, ref) => {
+    return (
+      <StyledFallback
+        ref={ref}
+        data-avatar="fallback"
+        css={{
+          $$subtleBg: `$colors$${colorScheme}3`,
+          $$subtleColor: `$colors$${colorScheme}11`,
+
+          $$solidBg: `$colors$${colorScheme}9`,
+          $$solidColor: getContrastingColor(colorScheme),
+          ...css,
+        }}
+        {...rest}
+      >
+        {children}
+      </StyledFallback>
+    );
+  }
+);
+
+type AvatarGroupProps = ComponentProps<typeof StyledAvatarGroup> &
+  AvatarProps & {
+    limit?: number;
+    avatarBorderWidth?: number | string;
+    avatarBorderColor?: string;
+  };
+
+const StyledAvatarGroup = styled('div', Flex, {
+  //resets
+  m: 0,
+  p: 0,
+
+  variants: {
+    stacking: {
+      firstOnTop: {
+        '& span': {
+          '&:not(:first-of-type)': {
+            ml: '-$3',
+          },
+        },
+      },
+      lastOnTop: {
+        '& span': {
+          '&:not(:last-of-type)': {
+            mr: '-$3',
+          },
+        },
+
+        // justifyContent: 'flex-end',
+        flexDirection: 'row-reverse',
+      },
+    },
+  },
+
+  defaultVariants: {
+    stacking: 'firstOnTop',
+  },
+});
+
+export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
+  (
+    { children, avatarBorderWidth = '3px', avatarBorderColor = 'inherit', limit, size, ...rest },
+    ref
+  ) => {
+    const validChildren = getValidChildren(children);
+
+    const childrenWithinLimit = limit ? validChildren.slice(0, limit) : validChildren;
+
+    const reversedChildren = childrenWithinLimit.reverse();
+
+    const _children = React.Children.map(reversedChildren, (child) => {
+      return React.cloneElement(child as React.ReactElement<AvatarProps>, {
+        css: { boxShadow: `0 0 0 ${avatarBorderWidth} $colors$slate1` },
+        size: size,
+      });
+    });
+    return (
+      <StyledAvatarGroup role="group" ref={ref} {...rest}>
+        {_children}
+        {limit && limit < validChildren.length && (
+          <Avatar size={size} data-avatar="fallback">
+            <AvatarFallback>+{validChildren.length - limit}</AvatarFallback>
+          </Avatar>
+        )}
+      </StyledAvatarGroup>
+    );
+  }
+);

--- a/packages/react/src/avatar/index.ts
+++ b/packages/react/src/avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar'

--- a/packages/react/src/utils/object-utils.ts
+++ b/packages/react/src/utils/object-utils.ts
@@ -1,0 +1,7 @@
+export function compact<T extends Record<any, any>>(object: T) {
+  const clone = Object.assign({}, object);
+  for (let key in clone) {
+    if (clone[key] === undefined) delete clone[key];
+  }
+  return clone;
+}

--- a/packages/react/src/utils/react-children.ts
+++ b/packages/react/src/utils/react-children.ts
@@ -1,0 +1,13 @@
+import { Children, isValidElement } from 'react';
+
+/**
+ * Will only return valid children elements of a component
+ *
+ * @param children
+ * @returns Array of valid `children` components
+ */
+export function getValidChildren(children: React.ReactNode) {
+  return Children.toArray(children).filter((child) =>
+    isValidElement(child)
+  ) as React.ReactElement[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ importers:
     specifiers:
       '@radix-ui/colors': 0.1.8
       '@radix-ui/react-aspect-ratio': 1.0.1
+      '@radix-ui/react-avatar': 1.0.1
       '@radix-ui/react-checkbox': 1.0.1
       '@radix-ui/react-dialog': 1.0.2
       '@radix-ui/react-dropdown-menu': 2.0.1
@@ -55,6 +56,7 @@ importers:
     dependencies:
       '@radix-ui/colors': 0.1.8
       '@radix-ui/react-aspect-ratio': 1.0.1_react@17.0.2
+      '@radix-ui/react-avatar': 1.0.1_react@17.0.2
       '@radix-ui/react-checkbox': 1.0.1_react@17.0.2
       '@radix-ui/react-dialog': 1.0.2_z7w6vgz62d5pbxpnoxayoqdmly
       '@radix-ui/react-dropdown-menu': 2.0.1_z7w6vgz62d5pbxpnoxayoqdmly
@@ -2909,6 +2911,20 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-primitive': 1.0.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@radix-ui/react-avatar/1.0.1_react@17.0.2:
+    resolution: {integrity: sha512-GfUgw4i/OWmb76bmM9qLnedYOsXhPvRXL6xaxyZzhiIVEwo2KbmxTaSQv5r1Oh8nNqBs1vfYPGuVmhEfpxpnvw==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-context': 1.0.0_react@17.0.2
+      '@radix-ui/react-primitive': 1.0.1_react@17.0.2
+      '@radix-ui/react-use-callback-ref': 1.0.0_react@17.0.2
+      '@radix-ui/react-use-layout-effect': 1.0.0_react@17.0.2
       react: 17.0.2
     dev: false
 


### PR DESCRIPTION
Things left to do: 

- [x] achieve alternate stacking without using zIndex
- [ ] improve API for changing border properties and spacing of avatar children within an `AvatarGroup` (consider compound variants)